### PR TITLE
Set a panic hook if use_std

### DIFF
--- a/src/lib.rs.liquid
+++ b/src/lib.rs.liquid
@@ -15,6 +15,11 @@ struct Settings {
 }{% endif %}
 
 async fn main() {
+{%- if use_std %}
+    std::panic::set_hook(Box::new(|panic_info| {
+        asr::print_message(&panic_info.to_string());
+    }));
+{% endif %}
     // TODO: Set up some general state and settings.{% if has_settings %}
     let mut settings = Settings::register();{% endif %}
 


### PR DESCRIPTION
As suggested by @CryZe in the Speedrun Tool Develop discord for improving error messages in the ASR debugger when it's using `std`.

When `use_std` is false, the start of `main` looks like
```
async fn main() {
    // TODO: Set up some general state and settings.
```
with no blank line between the `{` brace and the `TODO` comment.

And when `use_std` is true, the start of `main` looks like
```
async fn main() {
    std::panic::set_hook(Box::new(|panic_info| {
        asr::print_message(&panic_info.to_string());
    }));

    // TODO: Set up some general state and settings.
```
with a blank line between the `set_hook` call and the `TODO` comment.