### PR TITLE
Set GitHub Action permissions automatically

### DIFF
--- a/.github/workflows/build.yml.liquid
+++ b/.github/workflows/build.yml.liquid
@@ -12,6 +12,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions: 
+      contents: write
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v3


### PR DESCRIPTION
This fixes having to manually set the correct permissions for the GitHub Action to work.

This change originated from @CryZe in his [game-maker-auto-splitter](https://github.com/CryZe/game-maker-auto-splitter/tree/master) repository, this just upstreams it.